### PR TITLE
d/t/control: add debian-archive-keyring as a dependency of examples test

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -4,5 +4,5 @@ Restrictions: allow-stderr
 Features: test-name=unittest
 
 Tests: examples
-Depends: squashfs-tools-ng, ubuntu-keyring, @
+Depends: squashfs-tools-ng, ubuntu-keyring, debian-archive-keyring, @
 Restrictions: needs-root, allow-stderr


### PR DESCRIPTION
The `Debian-unstable.yml` file used in this test requires `/usr/share/keyrings/debian-archive-keyring.gpg` which is provided by
`debian-archive-keyring` and it is not installed by default in the Ubuntu testbed.

This is the log of the test failure in Ubuntu:

https://autopkgtest.ubuntu.com/results/autopkgtest-impish/impish/amd64/b/bdebstrap/20210511_204105_45ef7@/log.gz

With the proposed change it passed locally in Ubuntu:

```
autopkgtest [17:38:00]: @@@@@@@@@@@@@@@@@@@@ summary
unittest             PASS
examples             PASS
```