### PR TITLE
feat: change default yaml flow style to False

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /*.egg-info/
 /.pybuild/
 __pycache__/
+.coverage

--- a/bdebstrap
+++ b/bdebstrap
@@ -75,6 +75,7 @@ class Config(dict):
         super().__init__(self, *args, **kwargs)
         self.logger = logging.getLogger(__script_name__)
         self.yaml = ruamel.yaml.YAML()
+        self.yaml.default_flow_style = False
         self.yaml.explicit_start = True
         self.yaml.indent(offset=2, sequence=4)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -486,7 +486,7 @@ class TestConfig(unittest.TestCase):
         )
 
     def test_yaml_rendering(self) -> None:
-        """Test that config.yaml is formatted correctly."""
+        """Test that config.yaml is a syntactically valid yaml file."""
         config = Config()
         config_filename = os.path.join(EXAMPLE_CONFIG_DIR, "Debian-unstable.yaml")
         config.load(config_filename)
@@ -497,6 +497,16 @@ class TestConfig(unittest.TestCase):
         with open(config_filename, encoding="utf-8") as config_file:
             input_config = config_file.read()
         self.assertEqual(output_config, input_config)
+
+    def test_yaml_flow_style(self) -> None:
+        """Test that config.yaml follows the correct flow style."""
+        config = Config()
+        config["mmdebstrap"] = {"packages": ["1", "2", "3", "4", "5"]}
+        with tempfile.NamedTemporaryFile() as temp_file:
+            config.save(temp_file.name)
+            with open(temp_file.name, encoding="utf-8") as config_file:
+                lines = len(config_file.readlines())
+        self.assertEqual(lines, 8)
 
     def test_source_date_epoch(self) -> None:
         """Test getting and setting SOURCE_DATE_EPOCH."""


### PR DESCRIPTION
The default flow style is hard to read for non-trivial system configurations.

[Here](https://github.com/yaml/pyyaml/issues/199#issuecomment-420425200) is how different flow style looks like.

This is a real output we are currently generating with bdebstrap, which is hard to read: [config.yaml.txt](https://github.com/bdrung/bdebstrap/files/14174160/config.yaml.txt)

Readability is important because we have customers who want to customize our systems. In the past we have to teach them how to use our build system, but we plan to just let them make changes to the generated `config.yaml` and build it.

Extension name changed to pass GitHub upload rule.