### PR TITLE
Install data_files relative to prefix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,5 +119,5 @@ if __name__ == "__main__":
         install_requires=["ruamel.yaml"],
         scripts=["bdebstrap"],
         py_modules=[],
-        data_files=[("/usr/share/man/man1", MAN_PAGES), ("/usr/share/bdebstrap/hooks", HOOKS)],
+        data_files=[("share/man/man1", MAN_PAGES), ("share/bdebstrap/hooks", HOOKS)],
     )


### PR DESCRIPTION
Hi @bdrung 
I hit this problem installing 0.7.0 using pip. Without this change, bdebstrap cannot self-locate its hooks. The PR removes the absolute prefix from data_files, therefore making them relative to a specified install prefix instead. I'm not sure if this will impact deb packaging, but I couldn't see how it was packaged.